### PR TITLE
GH-2 - Add new target for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "start": "yarn build && node server/index.js",
     "build": "parcel build client/index.html",
+    "dev": "yarn build && node server/index.js",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --config .eslintrc.js ./client",
+    "start": "node server/index.js",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "typewatch": "tsc --noEmit --watch"


### PR DESCRIPTION
## Description
Linked Issue: GH-2
Heroku by default looks at `start` and `deploy` as specific targets w/ specific behavior.  To get around this I made a `dev` target that builds and serves everything

## Context
Want to use heroku for hosting but there are some nuances to getting it to work. 

## Checklist
- [x] Tests pass
- [ ] New tests added
- [x] Typescript checks pass
- [x] Code has been Linted