### PR TITLE
Update dev build to just use parcel and not express

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "parcel build client/index.html",
-    "dev": "yarn build && node server/index.js",
+    "dev": "parcel client/index.html",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --config .eslintrc.js ./client",
     "start": "node server/index.js",
     "test": "jest",


### PR DESCRIPTION
## Description
I realized I did a dumb switching from parcel's built in simple preview to the full express build and server for dev.  Switching back.

## Context
It should be easier to build stuff in dev than building and spinning up the server that Heroku needs.

## Checklist
- [x] Tests pass
- [x] New tests added
- [x] Typescript checks pass
- [x] Code has been Linted